### PR TITLE
Fix for sorting tabs in the containers and the containers themselves

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Container Tab Sorter",
-	"version": "0.3",
+	"version": "0.4",
 	"description": "Automatically sorts tabs based on their container",
 	"permissions": ["tabs", "contextualIdentities", "storage"],
 	"content_security_policy": "script-src 'self'; object-src 'self'",


### PR DESCRIPTION
This fixes two issues

- The tabs were not getting added to the end of the "already grouped" tabs of the same container
- The containers themselves were not getting sorted based on the order specified in the configuration